### PR TITLE
Extend routing syntax

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ public/*
 builds/*
 vendor/*
 composer.lock
+.idea/

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,5 +10,5 @@ before_script:
   - composer install
   
 script:
-  - phpunit --configuration phpunit.xml
+  - vendor/bin/phpunit --configuration phpunit.xml
   

--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ Download the [latest release](https://github.com/bearframework/bearframework/rel
 ## Documentation
 Documentation is available at [http://bearframework.com/documentation/](http://bearframework.com/documentation/).
 
+## How to run the tests
+After installing the dependencies with Composer, you will have a local version of PHPUnit. You can run the tests like this: `vendor/bin/phpunit tests/`.
+
 ## License
 Bear Framework is open-sourced software. It's free to use under the MIT license. See the [license file](https://github.com/bearframework/bearframework/blob/master/LICENSE) for more information.
 

--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,9 @@
         "ivopetkov/object-storage": "*",
         "ivopetkov/html-server-components-compiler": "*"
     },
+    "require-dev": {
+      "phpunit/phpunit": "^4.8"
+    },
     "autoload": {
         "psr-4": {
             "": "src/"

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -7,7 +7,7 @@
          stopOnFailure="true">
     <testsuites>
         <testsuite name="Bear Framework Test Suite">
-            <directory>./</directory>
+            <directory>./tests/</directory>
         </testsuite>
     </testsuites>
     <filter>

--- a/src/App/Routes.php
+++ b/src/App/Routes.php
@@ -55,6 +55,56 @@ class Routes
     }
 
     /**
+     * Register a GET route
+     *
+     * @param $pattern
+     * @param $callback
+     * @param array $additionalOptions\
+     */
+    public function get($pattern, $callback, $additionalOptions = [])
+    {
+        $this->add($pattern, $callback, array_merge(['GET', 'HEAD'], $additionalOptions));
+    }
+
+    /**
+     * Register a POST route
+     *
+     * @param $pattern
+     * @param $callback
+     * @param array $additionalOptions\
+     */
+    public function post($pattern, $callback, $additionalOptions = [])
+    {
+        $this->add($pattern, $callback, array_merge(['POST'], $additionalOptions));
+    }
+
+
+    /**
+     * Register a PUT route
+     *
+     * @param $pattern
+     * @param $callback
+     * @param array $additionalOptions\
+     */
+    public function put($pattern, $callback, $additionalOptions = [])
+    {
+        $this->add($pattern, $callback, array_merge(['PUT', 'PATCH'], $additionalOptions));
+    }
+
+
+    /**
+     * Register a DELETE route
+     *
+     * @param $pattern
+     * @param $callback
+     * @param array $additionalOptions\
+     */
+    public function delete($pattern, $callback, $additionalOptions = [])
+    {
+        $this->add($pattern, $callback, array_merge(['DELETE'], $additionalOptions));
+    }
+
+    /**
      * Finds the matching callback and returns its result
      * @param App\Request $request The current request object
      * @return mixed The result of the matching callback. NULL if none.

--- a/tests/RoutesTest.php
+++ b/tests/RoutesTest.php
@@ -479,4 +479,72 @@ class RoutesTest extends PHPUnit_Framework_TestCase
         $app->routes->getResponse(null);
     }
 
+    /**
+     * @runInSeparateProcess
+     */
+    public function testRegisterGetRoute()
+    {
+        $app = new App();
+
+        $app->request->path = new \App\Request\Path('/hello-world/');
+        $app->request->method = 'GET';
+        $app->routes->get('/hello-world/', function() {
+            return new \App\Response\HTML('It\'s me');
+        });
+
+        $app->run();
+        $this->expectOutputString('It\'s me');
+    }
+
+    /**
+     * @runInSeparateProcess
+     */
+    public function testRegisterPostRoute()
+    {
+        $app = new App();
+
+        $app->request->path = new \App\Request\Path('/hello-world-post/');
+        $app->request->method = 'POST';
+        $app->routes->post('/hello-world-post/', function() {
+            return new \App\Response\HTML('I\'m in California dreaming about who we used to be');
+        });
+
+        $app->run();
+        $this->expectOutputString('I\'m in California dreaming about who we used to be');
+    }
+
+    /**
+     * @runInSeparateProcess
+     */
+    public function testRegisterPutRoute()
+    {
+        $app = new App();
+
+        $app->request->path = new \App\Request\Path('/hello-world-put/');
+        $app->request->method = 'PUT';
+        $app->routes->put('/hello-world-put/', function() {
+            return new \App\Response\HTML('Hello from the other side');
+        });
+
+        $app->run();
+        $this->expectOutputString('Hello from the other side');
+    }
+
+    /**
+     * @runInSeparateProcess
+     */
+    public function testRegisterDeleteRoute()
+    {
+        $app = new App();
+
+        $app->request->path = new \App\Request\Path('/hello-world-delete/');
+        $app->request->method = 'DELETE';
+        $app->routes->delete('/hello-world-delete/', function() {
+            return new \App\Response\HTML('I must have called a thousand times');
+        });
+
+        $app->run();
+        $this->expectOutputString('I must have called a thousand times');
+    }
+
 }


### PR DESCRIPTION
Add shorthand syntax for defining routes. Sometimes it is easier and more readable to define the routes with the
HTTP verb that they will respond to, like GET, POST, etc.
